### PR TITLE
(No)Share has been renamed to (No)Sync in latest rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -392,7 +392,7 @@ impl Transform {
 pub struct Ctx {
     ptr: *mut ffi::NVGcontext,
     no_send: marker::NoSend,
-    no_share: marker::NoShare,
+    no_sync: marker::NoSync,
 }
 
 impl fmt::Show for Ctx {
@@ -414,7 +414,7 @@ impl Ctx {
         Ctx {
             ptr: unsafe { ffi::nvgCreateGL3(flags.bits) },
             no_send: marker::NoSend,
-            no_share: marker::NoShare,
+            no_sync: marker::NoSync,
         }
     }
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/commit/1f760d5d1a448c08ff4b66cfa8d35d39a5d667c0
