### PR TITLE
Replaced static keyword with const for global constants.

### DIFF
--- a/examples/demo/src/demo.rs
+++ b/examples/demo/src/demo.rs
@@ -8,15 +8,15 @@ use gl::{ReadPixels, RGBA, UNSIGNED_BYTE};
 use libc::{c_void};
 
 /// use unicode characters for icons
-static NO_ICON:            char = '\0';
-static ICON_SEARCH:        char = '\U0001F50D';
-static ICON_CIRCLED_CROSS: char = '\u2716';
-static ICON_CHEVRON_RIGHT: char = '\uE75E';
-static ICON_CHECK:         char = '\u2713';
-static ICON_LOGIN:         char = '\uE740';
-static ICON_TRASH:         char = '\uE729';
+const NO_ICON:            char = '\0';
+const ICON_SEARCH:        char = '\U0001F50D';
+const ICON_CIRCLED_CROSS: char = '\u2716';
+const ICON_CHEVRON_RIGHT: char = '\uE75E';
+const ICON_CHECK:         char = '\u2713';
+const ICON_LOGIN:         char = '\uE740';
+const ICON_TRASH:         char = '\uE729';
 
-static PI: f32 = 3.1415926535;
+const PI: f32 = 3.1415926535;
 
 fn min(a: f32, b: f32) -> f32 { if a < b { a } else { b } }
 fn max(a: f32, b: f32) -> f32 { if a > b { a } else { b } }
@@ -1171,4 +1171,3 @@ pub fn save_screenshot(w: u32, h: u32, premult: bool, name: &str)
     flip_image(image.as_mut_slice(), w, h, w*4);
      write_png(name, w, h, 4, &image.as_slice()[0], w*4);
 }
-

--- a/examples/demo/src/perf.rs
+++ b/examples/demo/src/perf.rs
@@ -14,7 +14,7 @@ pub enum Style {
     MS
 }
 
-static CAP:uint = 100;
+const CAP:uint = 100;
 
 pub struct PerfGraph {
 	pub style: Style,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -4,37 +4,37 @@ use libc::{c_double, c_float, c_int, c_char};
 use libc::{c_uint, c_ushort, c_uchar, c_void};
 use std::kinds::marker;
 
-pub static FONT_INVALID: c_int = -1;
-pub static STB_IMAGE_INVALID: c_int = 0;
+pub const FONT_INVALID: c_int = -1;
+pub const STB_IMAGE_INVALID: c_int = 0;
 
-pub static NVG_CCW: c_uint = 1;
-pub static NVG_CW: c_uint = 2;
+pub const NVG_CCW: c_uint = 1;
+pub const NVG_CW: c_uint = 2;
 
-pub static NVG_SOLID: c_uint = 1;
-pub static NVG_HOLE: c_uint = 2;
+pub const NVG_SOLID: c_uint = 1;
+pub const NVG_HOLE: c_uint = 2;
 
-pub static NVG_BUTT: c_uint = 0;
-pub static NVG_ROUND: c_uint = 1;
-pub static NVG_SQUARE: c_uint = 2;
-pub static NVG_BEVEL: c_uint = 3;
-pub static NVG_MITER: c_uint = 4;
+pub const NVG_BUTT: c_uint = 0;
+pub const NVG_ROUND: c_uint = 1;
+pub const NVG_SQUARE: c_uint = 2;
+pub const NVG_BEVEL: c_uint = 3;
+pub const NVG_MITER: c_uint = 4;
 
-pub static NVG_NOREPEAT: c_uint = 0;
-pub static NVG_REPEATX: c_uint = 1;
-pub static NVG_REPEATY: c_uint = 2;
+pub const NVG_NOREPEAT: c_uint = 0;
+pub const NVG_REPEATX: c_uint = 1;
+pub const NVG_REPEATY: c_uint = 2;
 
-pub static NVG_ALIGN_LEFT: c_uint = 1;
-pub static NVG_ALIGN_CENTER: c_uint = 2;
-pub static NVG_ALIGN_RIGHT: c_uint = 4;
-pub static NVG_ALIGN_TOP: c_uint = 8;
-pub static NVG_ALIGN_MIDDLE: c_uint = 16;
-pub static NVG_ALIGN_BOTTOM: c_uint = 32;
-pub static NVG_ALIGN_BASELINE: c_uint = 64;
+pub const NVG_ALIGN_LEFT: c_uint = 1;
+pub const NVG_ALIGN_CENTER: c_uint = 2;
+pub const NVG_ALIGN_RIGHT: c_uint = 4;
+pub const NVG_ALIGN_TOP: c_uint = 8;
+pub const NVG_ALIGN_MIDDLE: c_uint = 16;
+pub const NVG_ALIGN_BOTTOM: c_uint = 32;
+pub const NVG_ALIGN_BASELINE: c_uint = 64;
 
-pub static NVG_ANTIALIAS: c_uint = 1;
-pub static NVG_STENCIL_STROKES: c_uint = 2;
+pub const NVG_ANTIALIAS: c_uint = 1;
+pub const NVG_STENCIL_STROKES: c_uint = 2;
 
-pub static NVG_IMAGE_GENERATE_MIPMAPS: c_uint = 1;
+pub const NVG_IMAGE_GENERATE_MIPMAPS: c_uint = 1;
 
 pub enum NVGcontext {}
 
@@ -78,8 +78,8 @@ pub struct NVGtextRow {
 }
 
 pub type Enum_NVGtexture = c_uint;
-pub static NVG_TEXTURE_ALPHA: c_uint = 1;
-pub static NVG_TEXTURE_RGBA: c_uint = 2;
+pub const NVG_TEXTURE_ALPHA: c_uint = 1;
+pub const NVG_TEXTURE_RGBA: c_uint = 2;
 
 #[repr(C)]
 pub struct NVGscissor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,26 +66,26 @@ pub enum PatternRepeat {
 
 pub bitflags!(
     flags Align: u32 {
-        static LEFT         = ffi::NVG_ALIGN_LEFT,
-        static CENTER       = ffi::NVG_ALIGN_CENTER,
-        static RIGHT        = ffi::NVG_ALIGN_RIGHT,
-        static TOP          = ffi::NVG_ALIGN_TOP,
-        static MIDDLE       = ffi::NVG_ALIGN_MIDDLE,
-        static BOTTOM       = ffi::NVG_ALIGN_BOTTOM,
-        static BASELINE     = ffi::NVG_ALIGN_BASELINE
+        const LEFT         = ffi::NVG_ALIGN_LEFT,
+        const CENTER       = ffi::NVG_ALIGN_CENTER,
+        const RIGHT        = ffi::NVG_ALIGN_RIGHT,
+        const TOP          = ffi::NVG_ALIGN_TOP,
+        const MIDDLE       = ffi::NVG_ALIGN_MIDDLE,
+        const BOTTOM       = ffi::NVG_ALIGN_BOTTOM,
+        const BASELINE     = ffi::NVG_ALIGN_BASELINE
     }
 )
 
 pub bitflags!(
     flags CreationFlags: u32 {
-        static ANTIALIAS        = ffi::NVG_ANTIALIAS,
-        static STENCIL_STROKES  = ffi::NVG_STENCIL_STROKES
+        const ANTIALIAS        = ffi::NVG_ANTIALIAS,
+        const STENCIL_STROKES  = ffi::NVG_STENCIL_STROKES
     }
 )
 
 pub bitflags!(
     flags ImageFlags: u32 {
-        static GENERATE_MIPMAPS = ffi::NVG_IMAGE_GENERATE_MIPMAPS
+        const GENERATE_MIPMAPS = ffi::NVG_IMAGE_GENERATE_MIPMAPS
     }
 )
 
@@ -884,5 +884,3 @@ pub fn write_tga(filename: &str, w: u32, h: u32, comp: i32, data: *const u8) -> 
         unsafe { ffi::stbi_write_tga(filename, w as c_int, h as c_int, comp, data as *const c_void) }
     })
 }
-
-


### PR DESCRIPTION
This was a recent change integrated into the rust compiler as per RFC #246 https://github.com/rust-lang/rfcs/pull/246

This should fix issue #8.
