### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ Links
 - [NanoVG](https://github.com/memononen/nanovg)
 - [rust-bindgen](https://github.com/crabtw/rust-bindgen) (thanks!)
 - [gl-rs](https://github.com/bjz/gl-rs)
-- [glfw-rs](https://github.com/bjz/glfw-rs)
+- [glfw-rs](https://github.com/PistonDevelopers/glfw-rs)


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/bjz/glfw-rs | https://github.com/PistonDevelopers/glfw-rs 
