### PR TITLE
fix nanovg-rs for Rust 1.7.0

### DIFF
--- a/examples/demo/src/demo.rs
+++ b/examples/demo/src/demo.rs
@@ -635,7 +635,7 @@ fn draw_thumbnails(vg: &Context, x: f32, y: f32, w: f32, h: f32,
 
     let dv = 1.0 / (nimages as f32 - 1.0);
 
-    for i in (0..nimages) {
+    for i in 0..nimages {
         let mut tx = x+10.0;
         let mut ty = y+10.0;
         tx += (i%2) as f32 * (thumb+10.0);
@@ -909,7 +909,7 @@ fn draw_paragraph(vg: &Context, x: f32, y: f32, width: f32, height: f32, mx: f32
         let nrows = rows.len();
         if nrows == 0 { break 'chunks; }
 
-        for i in (0..nrows) {
+        for i in 0..nrows {
             let row = &rows[i];
             let hit: bool = mx > x && mx < (x+width) && my >= y && my < (y+lineh);
 
@@ -927,7 +927,7 @@ fn draw_paragraph(vg: &Context, x: f32, y: f32, width: f32, height: f32, mx: f32
                 let mut px = x;
                 let glyphs = vg.text_glyph_positions(x, y, line);
                 let nglyphs = glyphs.len();
-                for j in (0..nglyphs) {
+                for j in 0..nglyphs {
                     let x0 = glyphs[j].x();
                     let x1 = if j+1 < nglyphs { glyphs[j+1].x() } else { x+row.width() };
                     let gx = x0 * 0.3 + x1 * 0.7;
@@ -1068,10 +1068,10 @@ fn unpremultiply_alpha(image: &mut Vec<u8>, w: u32, h: u32, stride: u32)
     let w: usize = w as usize; let h: usize = h as usize; let stride: usize = stride as usize;
 
     // Unpremultiply
-    for y in (0..h) {
+    for y in 0..h {
         //unsigned char *row = &image[y*stride];
         let row = &mut image[y*stride..y*stride + w*4];
-        for x in (0..w) {
+        for x in 0..w {
             let pix = &mut row[x*4..x*4 + 4];
             let r = pix[0] as f32;
             let g = pix[1] as f32;
@@ -1086,8 +1086,8 @@ fn unpremultiply_alpha(image: &mut Vec<u8>, w: u32, h: u32, stride: u32)
     }
 
     // Defringe
-    for y in (0..h) {
-        for x in (0..w) {
+    for y in 0..h {
+        for x in 0..w {
             let ix = y*stride + x*4;
             let mut r = 0;
             let mut g = 0;
@@ -1132,9 +1132,9 @@ fn unpremultiply_alpha(image: &mut Vec<u8>, w: u32, h: u32, stride: u32)
 fn set_alpha(image: &mut Vec<u8>, w: u32, h: u32, stride: u32, a: u8)
 {
     let w: usize = w as usize; let h: usize = h as usize; let stride: usize = stride as usize;
-    for y in (0..h) {
+    for y in 0..h {
         let row = &mut image[y*stride..y*stride + w*4]; //&image[y*stride];
-        for x in (0..w) {
+        for x in 0..w {
             row[x*4+3] = a;
         }
     }
@@ -1151,7 +1151,7 @@ fn flip_image(image: &mut Vec<u8>, w: u32, h: u32, stride: u32)
         // error; can't borrow twice from the same source
         let ix: usize = i*stride;
         let jx: usize = j*stride;
-        for k in (0..w*4) {
+        for k in 0..w*4 {
             let t       = image[ix+k];  // let t = row_i[k];
             image[ix+k] = image[jx+k];  // row_i[k] = row_j[k];
             image[jx+k] = t;            // row_j[k] = t;

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -75,7 +75,7 @@ fn main()
     window.make_current();
 
     // use glfw to load GL function pointers
-    glcheck!(gl::load_with(|name| window.get_proc_address(name)));
+    glcheck!(gl::load_with(|name| window.get_proc_address(name) as *const _));
     init_gl();
 
    	let vg: nanovg::Context = nanovg::Context::create_gl3(nanovg::ANTIALIAS | nanovg::STENCIL_STROKES);

--- a/examples/demo/src/perf.rs
+++ b/examples/demo/src/perf.rs
@@ -61,7 +61,7 @@ impl PerfGraph
 		vg.move_to(x, y+h);
 		match self.style {
             Style::FPS => {
-    			for i in (0..CAP) { //(i = 0; i < CAP; i++) {
+    			for i in 0..CAP { //(i = 0; i < CAP; i++) {
     				let mut v = 1.0 / (0.00001 + self.values[(self.head+i) % CAP]);
     				if v > 80.0 {v = 80.0;}
     				let vx = x + (i as f32 / (CAP-1) as f32) * w;
@@ -70,7 +70,7 @@ impl PerfGraph
     			}
             }
             _ => {
-                for i in (0..CAP) {
+                for i in 0..CAP {
                     let mut v = self.values[(self.head+i) % CAP] * 1000.0;
                     if v > 20.0 {v = 20.0;}
                     let vx = x + (i as f32 / (CAP-1) as f32) * w;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,4 +1,4 @@
-#![allow(non_snake_case, non_camel_case_types, raw_pointer_derive)]
+#![allow(non_snake_case, non_camel_case_types)]
 
 use libc::{c_float, c_int, c_char};
 use libc::{c_uint, c_uchar, c_void};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -872,7 +872,7 @@ impl Context {
 
         // convert pointers to indexes
         let mut ret_vec:Vec<GlyphPosition> = Vec::with_capacity(actual_n);
-        for i in (0..actual_n) {
+        for i in 0..actual_n {
             let nvg = positions[i];
             ret_vec.push(GlyphPosition {
                 byte_index: relative_index(text, nvg.byte_ptr),
@@ -889,7 +889,7 @@ impl Context {
         let st = text.as_ptr() as *const i8;
         let en = unsafe { st.offset(text.len() as isize) };
         let mut rows: Vec<NVGtextRow> = Vec::with_capacity(max_rows);
-        for _ in (0..max_rows) {
+        for _ in 0..max_rows {
             rows.push(NVGtextRow {
                 start: ptr::null(),
                 end:   ptr::null(),
@@ -908,7 +908,7 @@ impl Context {
 
         // convert pointers to indexes
         let mut ret_vec:Vec<TextRow> = Vec::with_capacity(actual_n);
-        for i in (0..actual_n) {
+        for i in 0..actual_n {
             let nvg = rows[i];
             ret_vec.push(TextRow {
                 start_index: relative_index(text, nvg.start),


### PR DESCRIPTION
I modified it so as to pass through compilation in Rust 1.7.0, and removed some warnings.