### PR TITLE
Make example work with latest glfw

### DIFF
--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -81,7 +81,7 @@ fn main()
 
 //    return test_linebreaks(vg);
 
-	glfw.set_swap_interval(0);
+	glfw.set_swap_interval(glfw::SwapInterval::None);
 
 	glfw.set_time(0.0);
 	let mut prevt = glfw.get_time();


### PR DESCRIPTION
Fix for error:

```rust
error[E0308]: mismatched types
  --> src/main.rs:84:25
   |
84 | 	glfw.set_swap_interval(0);
   | 	                       ^ expected enum `glfw::SwapInterval`, found integral variable
   |
   = note: expected type `glfw::SwapInterval`
   = note:    found type `{integer}`
```