### PR TITLE
Fix TextBounds struct field visibility and traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1377,12 +1377,12 @@ impl Default for TextOptions {
 }
 
 /// Struct to store min and max bounds when measuring text with text_bounds or text_box_bounds
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct TextBounds {
-    min_x: f32,
-    min_y: f32,
-    max_x: f32,
-    max_y: f32,
+    pub min_x: f32,
+    pub min_y: f32,
+    pub max_x: f32,
+    pub max_y: f32,
 }
 
 impl TextBounds {


### PR DESCRIPTION
Adds missing Clone and Copy traits to TextBounds struct.
Makes fields of TextBounds visible.