### PR TITLE
Add text_glyph_positions function

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -125,7 +125,7 @@ pub struct NVGcompositeOperationState {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct NVGglyphPosition {
     pub s: *const c_char,
     pub x: c_float,


### PR DESCRIPTION
Adds missing text_glyph_positions function for calculating all glyph position in given text.
The function is implemented as iterator over all glyphs.