### PR TITLE
Improve matrix functions

### DIFF
--- a/examples/demo-clock.rs
+++ b/examples/demo-clock.rs
@@ -149,7 +149,7 @@ fn main() {
                     PathOptions {
                         composite_operation: CompositeOperation::Basic(BasicCompositeOperation::Lighter),
                         alpha: 1.0,
-                        transform: Some(Transform::new().rotate(m * radians_per_sec).translate(dial_center.0, dial_center.1)),
+                        transform: Some(Transform::new().translate(dial_center.0, dial_center.1).rotate(m * radians_per_sec)),
                         ..Default::default()
                     },
                 );
@@ -225,7 +225,7 @@ fn main() {
                     PathOptions {
                         composite_operation: CompositeOperation::Basic(BasicCompositeOperation::Lighter),
                         alpha: 1.0,
-                        transform: Some(Transform::new().rotate(theta).translate(dial_center.0, dial_center.1)),
+                        transform: Some(Transform::new().translate(dial_center.0, dial_center.1).rotate(theta)),
                         ..Default::default()
                     },
                 );

--- a/examples/demo-glutin.rs
+++ b/examples/demo-glutin.rs
@@ -110,7 +110,7 @@ fn main() {
                 PathOptions {
                     composite_operation: CompositeOperation::Basic(BasicCompositeOperation::Lighter),
                     alpha: elapsed.cos() * 0.5 + 0.5,
-                    transform: Some(Transform::new().scale(0.2, 1.0).translate(100.0, 50.0)),
+                    transform: Some(Transform::new().translate(100.0, 50.0).scale(0.2, 1.0)),
                     ..Default::default()
                 },
             );

--- a/examples/demo-ui.rs
+++ b/examples/demo-ui.rs
@@ -1004,7 +1004,7 @@ fn draw_scissor(frame: &Frame, x: f32, y: f32, t: f32) {
     );
 
     // let transform = transform.translate(40.0, 0.0).rotate(t);
-    let second_transform = Transform::new().translate(x + 40.0, y).rotate(t);
+    let second_transform = first_transform.translate(40.0, 0.0).rotate(t);
 
     frame.path(
         |path| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1701,7 +1701,7 @@ impl Transform {
     }
 
     /// Set the translation of the transform.
-    pub fn translate(self, x: f32, y: f32) -> Self {
+    pub fn with_translation(self, x: f32, y: f32) -> Self {
         let mut new = self.clone();
         new.matrix[4] = x;
         new.matrix[5] = y;
@@ -1709,7 +1709,7 @@ impl Transform {
     }
 
     /// Set the scale of the transform.
-    pub fn scale(self, x: f32, y: f32) -> Self {
+    pub fn with_scale(self, x: f32, y: f32) -> Self {
         let mut new = self.clone();
         new.matrix[0] = x;
         new.matrix[3] = y;
@@ -1717,7 +1717,7 @@ impl Transform {
     }
 
     /// Set the skew of the transform.
-    pub fn skew(self, x: f32, y: f32) -> Self {
+    pub fn with_skew(self, x: f32, y: f32) -> Self {
         let mut new = self.clone();
         new.matrix[2] = x;
         new.matrix[1] = y;
@@ -1725,12 +1725,67 @@ impl Transform {
     }
 
     /// Set the rotation of the transform.
-    pub fn rotate(self, theta: f32) -> Self {
+    pub fn with_rotation(self, theta: f32) -> Self {
         let mut new = self.clone();
         new.matrix[0] = theta.cos();
         new.matrix[2] = -theta.sin();
         new.matrix[1] = theta.sin();
         new.matrix[3] = theta.cos();
+        new
+    }
+
+    /// Translate transform by x and y.
+    pub fn translate(self, x: f32, y: f32) -> Self {
+        let mut new = self.clone();
+        let mut t = [0.0f32; 6];
+        unsafe {
+            ffi::nvgTransformTranslate(t.as_mut_ptr(), x, y);
+            ffi::nvgTransformPremultiply(new.matrix.as_mut_ptr(), t.as_mut_ptr());
+        }
+        new
+    }
+
+    /// Rotate transform with spcified angle.
+    pub fn rotate(self, angle: f32) -> Self {
+        let mut new = self.clone();
+        let mut t = [0.0f32; 6];
+        unsafe {
+            ffi::nvgTransformRotate(t.as_mut_ptr(), angle);
+            ffi::nvgTransformPremultiply(new.matrix.as_mut_ptr(), t.as_mut_ptr());
+        }
+        new
+    }
+
+    /// Skew transform along x axis with specified angle.
+    pub fn skew_x(self, angle: f32) -> Self {
+        let mut new = self.clone();
+        let mut t = [0.0f32; 6];
+        unsafe {
+            ffi::nvgTransformSkewX(t.as_mut_ptr(), angle);
+            ffi::nvgTransformPremultiply(new.matrix.as_mut_ptr(), t.as_mut_ptr());
+        }
+        new
+    }
+
+    /// Skew transform along y axis with specified angle.
+    pub fn skew_y(self, angle: f32) -> Self {
+        let mut new = self.clone();
+        let mut t = [0.0f32; 6];
+        unsafe {
+            ffi::nvgTransformSkewY(t.as_mut_ptr(), angle);
+            ffi::nvgTransformPremultiply(new.matrix.as_mut_ptr(), t.as_mut_ptr());
+        }
+        new
+    }
+
+    /// Scale transform along x and y.
+    pub fn scale(self, x: f32, y: f32) -> Self {
+        let mut new = self.clone();
+        let mut t = [0.0f32; 6];
+        unsafe {
+            ffi::nvgTransformScale(t.as_mut_ptr(), x, y);
+            ffi::nvgTransformPremultiply(new.matrix.as_mut_ptr(), t.as_mut_ptr());
+        }
         new
     }
 }


### PR DESCRIPTION
Matrix functions now changes and premultiplies previous matrix, so we can accumulate calls to Transform.
It is for example possible to translate then rotate and then translate again, making this approach more flexible. This also means that the order in which methods on Transform are called, matters. The setters are still there and are renamed to with_* methods so you can construct Transform with specified values. Every call clones previous Transform as it is with setter methods, so immutability is preserved. It is implemented by using underlying nanovg functions.