### PR TITLE
Remove frame, use context for every drawing

### DIFF
--- a/examples/demo-clock.rs
+++ b/examples/demo-clock.rs
@@ -103,7 +103,7 @@ fn main() {
 
 
 
-        context.frame((width, height), gl_window.hidpi_factor(), |frame| {
+        context.frame((width, height), gl_window.hidpi_factor(), |context| {
 
             // hour/minute markers
 
@@ -131,7 +131,7 @@ fn main() {
                 let ticks_radius = dial_radius * 0.925;
                 let tick_len = 3.0;
                 let tick_width = 1.0;
-                frame.path(
+                context.path(
                     |path| {
                         path.move_to((0.0, -ticks_radius));
                         path.line_to((0.0, -ticks_radius-tick_len));
@@ -185,7 +185,7 @@ fn main() {
 
 
             //Draw the dial
-            frame.path(
+            context.path(
                 |path| {
                     path.circle(origin, dial_radius);
                     path.stroke(StrokeStyle {
@@ -207,7 +207,7 @@ fn main() {
             );
 
             let draw_hand = |theta: f32, length: f32, width: f32| {
-                frame.path(
+                context.path(
                     |path| {
                         path.move_to(origin);
                         path.line_to((0.0, -length));
@@ -244,7 +244,7 @@ fn main() {
 
 
             //Draw the boss
-            frame.path(
+            context.path(
                 |path| {
                     let boss_rad = 6.0;
                     path.circle(origin, boss_rad);

--- a/examples/demo-cutout.rs
+++ b/examples/demo-cutout.rs
@@ -8,7 +8,7 @@ extern crate lazy_static;
 
 use std::time::Instant;
 use glutin::GlContext;
-use nanovg::{Color, ColoringStyle, FillStyle, Frame, Solidity, Winding, Transform, PathOptions, StrokeStyle};
+use nanovg::{Color, ColoringStyle, FillStyle, Context, Solidity, Winding, Transform, PathOptions, StrokeStyle};
 use rand::{Rng, Rand, thread_rng};
 use std::collections::HashMap;
 use std::f32::consts::PI;
@@ -83,13 +83,13 @@ fn main() {
 
         smoothed_mouse = smooth_mouse(mouse, smoothed_mouse, delta_time, 7.0);
 
-        context.frame((width, height), gl_window.hidpi_factor(), |frame| {
+        context.frame((width, height), gl_window.hidpi_factor(), |context| {
             let (width, height) = (width as f32, height as f32);
             let block_size = 75.0;
             let offset = block_size / 2.0;
 
             // background
-            render_rectangle(&frame, (0.0, 0.0), (width, height), Color::from_rgb(0xFF, 0xFF, 0xAF));
+            render_rectangle(&context, (0.0, 0.0), (width, height), Color::from_rgb(0xFF, 0xFF, 0xAF));
 
             let max_cols = (width / block_size) as u16 + 2;
             let max_rows = (height / block_size) as u16 + 2;
@@ -100,11 +100,11 @@ fn main() {
                     shape.update(delta_time);
                     let x = x as f32 * block_size - offset;
                     let y = y as f32 * block_size - offset;
-                    shape.draw(&frame, (x, y), block_size);
+                    shape.draw(&context, (x, y), block_size);
                 }
             }
 
-            render_cutout(&frame, (0.0, 0.0), (width, height), smoothed_mouse);
+            render_cutout(&context, (0.0, 0.0), (width, height), smoothed_mouse);
         });
 
         gl_window.swap_buffers().unwrap();
@@ -200,8 +200,8 @@ impl Shape {
         self.rotation = self.rotation + dt * self.speed;
     }
 
-    // Draws shape onto 'frame' at specified position, with available square area with side length of 'size'.
-    fn draw(&self, frame: &Frame, (x, y): (f32, f32), size: f32) {
+    // Draws shape onto 'context' at specified position, with available square area with side length of 'size'.
+    fn draw(&self, context: &Context, (x, y): (f32, f32), size: f32) {
         let margin = size * 0.2;
         let x = x + margin;
         let y = y + margin;
@@ -209,8 +209,8 @@ impl Shape {
         let half_size = size / 2.0;
         let pos = (x + half_size, y + half_size);
         match self.kind {
-            ShapeKind::Polygon(sides) => Shape::render_polygon(frame, pos, size, self.rotation, self.color, sides),
-            ShapeKind::Squiggle(phi) => Shape::render_squiggle(frame, pos, (size, size / 3.0), self.rotation, self.color, phi),
+            ShapeKind::Polygon(sides) => Shape::render_polygon(context, pos, size, self.rotation, self.color, sides),
+            ShapeKind::Squiggle(phi) => Shape::render_squiggle(context, pos, (size, size / 3.0), self.rotation, self.color, phi),
         };
     }
 
@@ -218,13 +218,13 @@ impl Shape {
     /// 'color' The colors of the shape.
     /// 'rotation' Specifies the rotation of shape in radians.
     /// 'num_sides' Number of polygon sides.
-    fn render_polygon(frame: &Frame, (cx, cy): (f32, f32), diameter: f32, rotation: f32, color: Color, num_sides: u8) {
+    fn render_polygon(context: &Context, (cx, cy): (f32, f32), diameter: f32, rotation: f32, color: Color, num_sides: u8) {
         assert!(num_sides >= 3);
 
         let radius = diameter / 2.0;
         let num_sides = num_sides as u32;
 
-        frame.path(
+        context.path(
             |path| {
                 path.move_to((Shape::get_polygon_point(0, num_sides, radius)));
                 for i in 1..num_sides {
@@ -247,7 +247,7 @@ impl Shape {
     /// 'color' The colors of the shape.
     /// 'rotation' Specifies the rotation of shape in radians.
     /// 'phi' Specifies number of peaks (oscillations).
-    fn render_squiggle(frame: &Frame, (cx, cy): (f32, f32), (w, h): (f32, f32), rotation: f32, color: Color, phi: u8) {
+    fn render_squiggle(context: &Context, (cx, cy): (f32, f32), (w, h): (f32, f32), rotation: f32, color: Color, phi: u8) {
         let phi = phi as f32;
         let mut points = [(0.0, 0.0); 64];
         for i in 0..points.len() {
@@ -258,7 +258,7 @@ impl Shape {
             points[i as usize] = (sx, sy);
         }
 
-        frame.path(
+        context.path(
             |path| {
                 path.move_to(points[0]);
                 for point in points.iter().skip(1) {
@@ -301,10 +301,10 @@ fn get_elapsed(instant: &Instant) -> f32 {
 }
 
 /// Renders foreground with hole cut in it.
-fn render_cutout(frame: &Frame, (x, y): (f32, f32), (w, h): (f32, f32), (mx, my): (f32, f32)) {
+fn render_cutout(context: &Context, (x, y): (f32, f32), (w, h): (f32, f32), (mx, my): (f32, f32)) {
     let base_circle_size = 200.0;
     let circle_thickness = 25.0;
-    frame.path(
+    context.path(
         |path| {
             path.rect((x, y), (w, h));
             path.move_to((0.0, 0.0));
@@ -319,7 +319,7 @@ fn render_cutout(frame: &Frame, (x, y): (f32, f32), (w, h): (f32, f32), (mx, my)
         Default::default()
     );
 
-    frame.path(
+    context.path(
         |path| {
             path.move_to((0.0, 0.0));
             path.circle((mx, my), base_circle_size + circle_thickness);
@@ -334,7 +334,7 @@ fn render_cutout(frame: &Frame, (x, y): (f32, f32), (w, h): (f32, f32), (mx, my)
         Default::default()
     );
 
-    frame.path(
+    context.path(
         |path| {
             path.move_to((0.0, 0.0));
             path.circle((mx, my), base_circle_size);
@@ -352,8 +352,8 @@ fn render_cutout(frame: &Frame, (x, y): (f32, f32), (w, h): (f32, f32), (mx, my)
 }
 
 /// Renders rectangle on position with specified dimensions and color.
-fn render_rectangle(frame: &Frame, (x, y): (f32, f32), (w, h): (f32, f32), color: Color) {
-    frame.path(
+fn render_rectangle(context: &Context, (x, y): (f32, f32), (w, h): (f32, f32), color: Color) {
+    context.path(
         |path| {
             path.rect((x, y), (w, h));
             path.fill(FillStyle {

--- a/examples/demo-glutin.rs
+++ b/examples/demo-glutin.rs
@@ -69,9 +69,9 @@ fn main() {
 
         // Let's draw a frame!
 
-        context.frame((width, height), gl_window.hidpi_factor(), |frame| {
+        context.frame((width, height), gl_window.hidpi_factor(), |context| {
             // Draw red-filled rectangle.
-            frame.path(
+            context.path(
                 |path| {
                     path.rect((100.0, 100.0), (300.0, 300.0));
                     path.fill(FillStyle {
@@ -88,7 +88,7 @@ fn main() {
             );
 
             // Draw custom yellow/blue shape.
-            frame.path(
+            context.path(
                 |path| {
                     let origin = (150.0, 140.0);
                     path.circle(origin, 64.0);
@@ -115,7 +115,7 @@ fn main() {
             );
 
             // Draw rolling image (with scissors)
-            frame.path(
+            context.path(
                 |path| {
                     let radius = 100.0;
                     let distance = 500.0; // Distance to roll
@@ -146,7 +146,7 @@ fn main() {
             );
 
             // Draw stroked rectangle.
-            frame.path(
+            context.path(
                 |path| {
                     path.rect((300.0, 310.0), (300.0, 300.0));
                     let color = Color::lerp(

--- a/examples/demo-ui.rs
+++ b/examples/demo-ui.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 use std::f32::consts;
 use rand::Rng;
 use glutin::GlContext;
-use nanovg::{Direction, Alignment, Color, ColoringStyle, FillStyle, Font, Frame,
+use nanovg::{Direction, Alignment, Color, ColoringStyle, FillStyle, Font,
              LineCap, LineJoin, Paint, PathOptions, Scissor, Solidity, StrokeStyle,
              TextOptions, Transform, Winding, Image, Context};
 
@@ -97,9 +97,9 @@ fn main() {
             gl::Clear(gl::COLOR_BUFFER_BIT | gl::DEPTH_BUFFER_BIT | gl::STENCIL_BUFFER_BIT);
         }
 
-        context.frame((width, height), gl_window.hidpi_factor(), |frame| {
+        context.frame((width, height), gl_window.hidpi_factor(), |context| {
             render_demo(
-                &frame,
+                &context,
                 mx,
                 my,
                 width as f32,
@@ -108,9 +108,9 @@ fn main() {
                 &demo_data,
             );
 
-            fps_graph.draw(&frame, demo_data.fonts.sans, 5.0, 5.0);
-            cpu_graph.draw(&frame, demo_data.fonts.sans, 5.0 + 200.0 + 5.0, 5.0);
-            rng_graph.draw(&frame, demo_data.fonts.sans, 5.0 + 200.0 + 5.0 + 200.0 + 5.0, 5.0);
+            fps_graph.draw(&context, demo_data.fonts.sans, 5.0, 5.0);
+            cpu_graph.draw(&context, demo_data.fonts.sans, 5.0 + 200.0 + 5.0, 5.0);
+            rng_graph.draw(&context, demo_data.fonts.sans, 5.0 + 200.0 + 5.0 + 200.0 + 5.0, 5.0);
         });
 
         fps_graph.update(delta_time);
@@ -184,61 +184,61 @@ fn clamp(value: f32, min: f32, max: f32) -> f32 {
     }
 }
 
-fn render_demo(frame: &Frame, mx: f32, my: f32, width: f32, height: f32, t: f32, data: &DemoData) {
-    draw_eyes(frame, width - 250.0, 50.0, 150.0, 100.0, mx, my, t);
-    draw_paragraph(frame, &data.fonts, width - 450.0, 50.0, 150.0, 100.0, mx, my);
-    draw_graph(frame, 0.0, height / 2.0, width, height / 2.0, t);
-    draw_color_wheel(frame, width - 300.0, height - 300.0, 250.0, 250.0, t);
-    draw_lines(frame, 120.0, height - 50.0, 600.0, 50.0, t);
-    draw_widths(frame, 10.0, 50.0, 30.0);
-    draw_caps(frame, 10.0, 300.0, 30.0);
-    draw_scissor(frame, 50.0, height - 80.0, t);
+fn render_demo(context: &Context, mx: f32, my: f32, width: f32, height: f32, t: f32, data: &DemoData) {
+    draw_eyes(context, width - 250.0, 50.0, 150.0, 100.0, mx, my, t);
+    draw_paragraph(context, &data.fonts, width - 450.0, 50.0, 150.0, 100.0, mx, my);
+    draw_graph(context, 0.0, height / 2.0, width, height / 2.0, t);
+    draw_color_wheel(context, width - 300.0, height - 300.0, 250.0, 250.0, t);
+    draw_lines(context, 120.0, height - 50.0, 600.0, 50.0, t);
+    draw_widths(context, 10.0, 50.0, 30.0);
+    draw_caps(context, 10.0, 300.0, 30.0);
+    draw_scissor(context, 50.0, height - 80.0, t);
 
     let mut x = 50.0;
     let mut y = 50.0;
     // widgets
-    draw_window(frame, &data.fonts, "Widgets `n stuff", x, y, 300.0, 400.0);
+    draw_window(context, &data.fonts, "Widgets `n stuff", x, y, 300.0, 400.0);
     x += 10.0;
     y += 45.0;
 
-    draw_search_box(frame, &data.fonts, "Search", x, y, 280.0, 25.0);
+    draw_search_box(context, &data.fonts, "Search", x, y, 280.0, 25.0);
     y += 40.0;
 
-    draw_drop_down(frame, &data.fonts, "Effects", x, y, 280.0,28.0);
+    draw_drop_down(context, &data.fonts, "Effects", x, y, 280.0,28.0);
     let popy = y + 14.0;
     y += 45.0;
 
     // form
-    draw_label(frame, &data.fonts, "Login", x, y, 280.0, 20.0);
+    draw_label(context, &data.fonts, "Login", x, y, 280.0, 20.0);
     y += 25.0;
 
-    draw_edit_box(frame, &data.fonts, "Email", x, y, 280.0, 28.0);
+    draw_edit_box(context, &data.fonts, "Email", x, y, 280.0, 28.0);
     y += 35.0;
 
-    draw_edit_box(frame, &data.fonts, "Password", x, y, 280.0, 28.0);
+    draw_edit_box(context, &data.fonts, "Password", x, y, 280.0, 28.0);
     y += 38.0;
 
-    draw_check_box(frame, &data.fonts, "Remember me", x, y, 140.0, 28.0);
-    draw_button(frame, &data.fonts, Some(ICON_LOGIN), "Sign in", x + 138.0, y, 140.0, 28.0, Color::from_rgba(0, 96, 128, 255));
+    draw_check_box(context, &data.fonts, "Remember me", x, y, 140.0, 28.0);
+    draw_button(context, &data.fonts, Some(ICON_LOGIN), "Sign in", x + 138.0, y, 140.0, 28.0, Color::from_rgba(0, 96, 128, 255));
     y += 45.0;
 
     // slider
-    draw_label(frame, &data.fonts, "Diameter", x, y, 280.0, 20.0);
+    draw_label(context, &data.fonts, "Diameter", x, y, 280.0, 20.0);
     y += 25.0;
 
-    draw_edit_box_num(frame, &data.fonts, "128.00", "px", x + 180.0, y, 100.0, 28.0, );
+    draw_edit_box_num(context, &data.fonts, "128.00", "px", x + 180.0, y, 100.0, 28.0, );
 
-    draw_slider(frame, 0.4, x, y, 170.0, 28.0);
+    draw_slider(context, 0.4, x, y, 170.0, 28.0);
     y += 55.0;
 
-    draw_button(frame, &data.fonts, Some(ICON_TRASH), "Delete", x, y, 160.0, 28.0, Color::from_rgba(128, 16, 8, 255));
+    draw_button(context, &data.fonts, Some(ICON_TRASH), "Delete", x, y, 160.0, 28.0, Color::from_rgba(128, 16, 8, 255));
 
-    draw_button(frame, &data.fonts, None, "Cancel", x + 170.0, y, 110.0, 28.0, Color::from_rgba(0, 0, 0, 0));
+    draw_button(context, &data.fonts, None, "Cancel", x + 170.0, y, 110.0, 28.0, Color::from_rgba(0, 0, 0, 0));
 
-    draw_thumbnails(frame, &data.images, 365.0, popy - 30.0, 160.0, 300.0, t);
+    draw_thumbnails(context, &data.images, 365.0, popy - 30.0, 160.0, 300.0, t);
 }
 
-fn draw_eyes(frame: &Frame, x: f32, y: f32, w: f32, h: f32, mx: f32, my: f32, t: f32) {
+fn draw_eyes(context: &Context, x: f32, y: f32, w: f32, h: f32, mx: f32, my: f32, t: f32) {
     let ex = w * 0.23;
     let ey = h * 0.5;
     let lx = x + ex;
@@ -249,7 +249,7 @@ fn draw_eyes(frame: &Frame, x: f32, y: f32, w: f32, h: f32, mx: f32, my: f32, t:
     let blink = 1.0 - ((t * 0.5).sin()).powf(200.0) * 0.8;
 
     // eye shades
-    frame.path(
+    context.path(
         |path| {
             path.ellipse((lx + 3.0, ly + 16.0), ex, ey);
             path.ellipse((rx + 3.0, ry + 16.0), ex, ey);
@@ -268,7 +268,7 @@ fn draw_eyes(frame: &Frame, x: f32, y: f32, w: f32, h: f32, mx: f32, my: f32, t:
     );
 
     // eye whites
-    frame.path(
+    context.path(
         |path| {
             path.ellipse((lx, ly), ex, ey);
             path.ellipse((rx, ry), ex, ey);
@@ -287,7 +287,7 @@ fn draw_eyes(frame: &Frame, x: f32, y: f32, w: f32, h: f32, mx: f32, my: f32, t:
     );
 
     // eye pupils
-    frame.path(
+    context.path(
         |path| {
             let mut dx = (mx - rx) / (ex * 10.0);
             let mut dy = (my - ry) / (ey * 10.0);
@@ -320,12 +320,12 @@ fn draw_eyes(frame: &Frame, x: f32, y: f32, w: f32, h: f32, mx: f32, my: f32, t:
     );
 
     // left eye gloss
-    frame.path(
+    context.path(
         |path| {
             path.ellipse((lx, ly), ex, ey);
             path.fill(FillStyle {
                 coloring_style: ColoringStyle::Paint(Paint::with_radial_gradient(
-                    (lx - ex * 0.25, ly - ey * 0.5),
+                   (lx - ex * 0.25, ly - ey * 0.5),
                     ex * 0.1,
                     ex * 0.75,
                     Color::from_rgba(255, 255, 255, 128),
@@ -338,7 +338,7 @@ fn draw_eyes(frame: &Frame, x: f32, y: f32, w: f32, h: f32, mx: f32, my: f32, t:
     );
 
     // right eye gloss
-    frame.path(
+    context.path(
         |path| {
             path.ellipse((rx, ry), ex, ey);
             path.fill(FillStyle {
@@ -356,7 +356,7 @@ fn draw_eyes(frame: &Frame, x: f32, y: f32, w: f32, h: f32, mx: f32, my: f32, t:
     );
 }
 
-fn draw_paragraph(frame: &Frame, fonts: &DemoFonts, x: f32, y: f32, width: f32, _height: f32, mx: f32, my: f32) {
+fn draw_paragraph(context: &Context, fonts: &DemoFonts, x: f32, y: f32, width: f32, _height: f32, mx: f32, my: f32) {
     let text = "This is longer chunk of text.\n  \n  Would have used lorem ipsum but she    was busy jumping over the lazy dog with the fox and all the men who came to the aid of the party.🎉";
     let text_options = TextOptions {
         color: Color::from_rgba(255, 255, 255, 255),
@@ -364,7 +364,7 @@ fn draw_paragraph(frame: &Frame, fonts: &DemoFonts, x: f32, y: f32, width: f32, 
         align: Alignment::new().left().top(),
         ..Default::default()
     };
-    let metrics = frame.context().text_metrics(fonts.sans, text_options);
+    let metrics = context.text_metrics(fonts.sans, text_options);
 
     let mut gutter_line = 0;
     let mut gutter_x = 0.0f32;
@@ -372,12 +372,12 @@ fn draw_paragraph(frame: &Frame, fonts: &DemoFonts, x: f32, y: f32, width: f32, 
 
     let mut y = y;
     let mut line_number = 0;
-    for row in frame.context().text_break_lines(text, width) {
+    for row in context.text_break_lines(text, width) {
         line_number += 1;
         let hit = mx > x && mx < (x + width) && my >= y && my < (y + metrics.line_height);
 
         // draw line background
-        frame.path(
+        context.path(
             |path| {
                 path.rect((x, y), (row.width, metrics.line_height));
                 path.fill(FillStyle {
@@ -389,7 +389,7 @@ fn draw_paragraph(frame: &Frame, fonts: &DemoFonts, x: f32, y: f32, width: f32, 
         );
 
         // draw line text
-        frame.context().text(
+        context.text(
             fonts.sans,
             (x, y),
             row.text,
@@ -401,7 +401,7 @@ fn draw_paragraph(frame: &Frame, fonts: &DemoFonts, x: f32, y: f32, width: f32, 
             let mut px = x;
 
             // calculate mouse caret position
-            for glyph in frame.context().text_glyph_positions((x, y), row.text) {
+            for glyph in context.text_glyph_positions((x, y), row.text) {
                 let x0 = glyph.x;
                 let x1 = if let Some(next) = *glyph.next { next.x } else { x + row.width };
                 let gx = x0 * 0.3 + x1 * 0.7;
@@ -415,7 +415,7 @@ fn draw_paragraph(frame: &Frame, fonts: &DemoFonts, x: f32, y: f32, width: f32, 
             }
 
             // draw mouse caret
-            frame.path(
+            context.path(
                 |path| {
                     path.rect((caretx, y), (1.0, metrics.line_height));
                     path.fill(FillStyle {
@@ -446,8 +446,8 @@ fn draw_paragraph(frame: &Frame, fonts: &DemoFonts, x: f32, y: f32, width: f32, 
             align: Alignment::new().right().middle(),
             ..Default::default()
         };
-        let (_, bounds) = frame.context().text_bounds(fonts.sans, (gx, gy), &gutter_text, gutter_text_options);
-        frame.path(
+        let (_, bounds) = context.text_bounds(fonts.sans, (gx, gy), &gutter_text, gutter_text_options);
+        context.path(
             |path| {
                 path.rounded_rect(
                     (bounds.min_x - 4.0, bounds.min_y - 2.0),
@@ -462,7 +462,7 @@ fn draw_paragraph(frame: &Frame, fonts: &DemoFonts, x: f32, y: f32, width: f32, 
             },
             Default::default()
         );
-        frame.context().text(fonts.sans, (gx, gy), &gutter_text, gutter_text_options);
+        context.text(fonts.sans, (gx, gy), &gutter_text, gutter_text_options);
     }
 
     y += 20.0;
@@ -477,13 +477,13 @@ fn draw_paragraph(frame: &Frame, fonts: &DemoFonts, x: f32, y: f32, width: f32, 
         ..Default::default()
     };
     // draw tooltip
-    let bounds = frame.context().text_box_bounds(fonts.sans, (x, y), tooltip_text, tooltip_opts);
+    let bounds = context.text_box_bounds(fonts.sans, (x, y), tooltip_text, tooltip_opts);
     let gx = f32::abs((mx - (bounds.min_x + bounds.max_x) * 0.5) / (bounds.min_x - bounds.max_x));
     let gy = f32::abs((my - (bounds.min_y + bounds.max_y) * 0.5) / (bounds.min_y - bounds.max_y));
     let alpha = f32::max(gx, gy) - 0.5;
     let alpha = clamp(alpha, 0.0, 1.0);
 
-    frame.path(
+    context.path(
         |path| {
             path.rounded_rect(
                 (bounds.min_x - 2.0, bounds.min_y - 2.0),
@@ -506,10 +506,10 @@ fn draw_paragraph(frame: &Frame, fonts: &DemoFonts, x: f32, y: f32, width: f32, 
         }
     );
 
-    frame.context().text_box(fonts.sans, (x, y), tooltip_text, tooltip_opts);
+    context.text_box(fonts.sans, (x, y), tooltip_text, tooltip_opts);
 }
 
-fn draw_graph(frame: &Frame, x: f32, y: f32, w: f32, h: f32, t: f32) {
+fn draw_graph(context: &Context, x: f32, y: f32, w: f32, h: f32, t: f32) {
     let mut samples = [0.0f32; 6];
     let mut sx = [0.0f32; 6];
     let mut sy = [0.0f32; 6];
@@ -528,7 +528,7 @@ fn draw_graph(frame: &Frame, x: f32, y: f32, w: f32, h: f32, t: f32) {
     }
 
     // graph background
-    frame.path(
+    context.path(
         |path| {
             path.move_to((sx[0], sy[0]));
             for i in 1..6 {
@@ -556,7 +556,7 @@ fn draw_graph(frame: &Frame, x: f32, y: f32, w: f32, h: f32, t: f32) {
     );
 
     // graph line (darker)
-    frame.path(
+    context.path(
         |path| {
             path.move_to((sx[0], sy[0] + 2.0));
             for i in 1..6 {
@@ -577,7 +577,7 @@ fn draw_graph(frame: &Frame, x: f32, y: f32, w: f32, h: f32, t: f32) {
     );
 
     // graph line (lighter)
-    frame.path(
+    context.path(
         |path| {
             path.move_to((sx[0], sy[0]));
             for i in 1..6 {
@@ -599,7 +599,7 @@ fn draw_graph(frame: &Frame, x: f32, y: f32, w: f32, h: f32, t: f32) {
 
     // graph sample points (background shades)
     for i in 0..6 {
-        frame.path(
+        context.path(
             |path| {
                 path.rect((sx[i] - 10.0, sy[i] - 10.0 + 2.0), (20.0, 20.0));
                 path.fill(FillStyle {
@@ -618,7 +618,7 @@ fn draw_graph(frame: &Frame, x: f32, y: f32, w: f32, h: f32, t: f32) {
     }
 
     // graph sample points (main dots)
-    frame.path(
+    context.path(
         |path| {
             for i in 0..6 {
                 path.circle((sx[i], sy[i]), 4.0);
@@ -633,7 +633,7 @@ fn draw_graph(frame: &Frame, x: f32, y: f32, w: f32, h: f32, t: f32) {
     );
 
     // graph sample points (small white dots)
-    frame.path(
+    context.path(
         |path| {
             for i in 0..6 {
                 path.circle((sx[i], sy[i]), 2.0);
@@ -648,7 +648,7 @@ fn draw_graph(frame: &Frame, x: f32, y: f32, w: f32, h: f32, t: f32) {
     );
 }
 
-fn draw_color_wheel(frame: &Frame, x: f32, y: f32, w: f32, h: f32, t: f32) {
+fn draw_color_wheel(context: &Context, x: f32, y: f32, w: f32, h: f32, t: f32) {
     let cx = x + w * 0.5;
     let cy = y + h * 0.5;
     let r1 = if w < h { w } else { h } * 0.5 - 5.0;
@@ -661,7 +661,7 @@ fn draw_color_wheel(frame: &Frame, x: f32, y: f32, w: f32, h: f32, t: f32) {
         let a1 = (i as f32 + 1.0) / 6.0 * consts::PI * 2.0 + aeps;
 
         // draw color segment gradient
-        frame.path(
+        context.path(
             |path| {
                 path.arc((cx, cy), r0, a0, a1, Winding::Direction(Direction::Clockwise));
                 path.arc((cx, cy), r1, a1, a0, Winding::Direction(Direction::CounterClockwise));
@@ -684,7 +684,7 @@ fn draw_color_wheel(frame: &Frame, x: f32, y: f32, w: f32, h: f32, t: f32) {
     }
 
     // draw circle outlines
-    frame.path(
+    context.path(
         |path| {
             path.circle((cx, cy), r0 - 0.5);
             path.circle((cx, cy), r1 + 0.5);
@@ -700,7 +700,7 @@ fn draw_color_wheel(frame: &Frame, x: f32, y: f32, w: f32, h: f32, t: f32) {
     let transform = Transform::new().translate(cx, cy).rotate(hue * consts::PI * 2.0);
 
     // color selector
-    frame.path(
+    context.path(
         |path| {
             path.rect((r0 - 1.0, -3.0), (r1 - r0 + 2.0, 6.0));
             path.stroke(StrokeStyle {
@@ -716,7 +716,7 @@ fn draw_color_wheel(frame: &Frame, x: f32, y: f32, w: f32, h: f32, t: f32) {
     );
 
     // color marker inside selector
-    frame.path(
+    context.path(
         |path| {
             path.rect((r0 - 2.0 - 10.0, -4.0 - 10.0), (r1 - r0 + 4.0 + 20.0, 8.0 + 20.0));
             path.move_to((0.0, 0.0));
@@ -743,7 +743,7 @@ fn draw_color_wheel(frame: &Frame, x: f32, y: f32, w: f32, h: f32, t: f32) {
     let r = r0 - 6.0;
 
     // center triangle
-    frame.path(
+    context.path(
         |path| {
             let ax = f32::cos(120.0 / 180.0 * consts::PI) * r;
             let ay = f32::sin(120.0 / 180.0 * consts::PI) * r;
@@ -789,7 +789,7 @@ fn draw_color_wheel(frame: &Frame, x: f32, y: f32, w: f32, h: f32, t: f32) {
     let ay = f32::sin(120.0 / 180.0 * consts::PI) * r * 0.4;
 
     // select circle on triangle
-    frame.path(
+    context.path(
         |path| {
             path.circle((ax, ay), 5.0);
             path.stroke(StrokeStyle {
@@ -805,7 +805,7 @@ fn draw_color_wheel(frame: &Frame, x: f32, y: f32, w: f32, h: f32, t: f32) {
     );
 
     // select circle outline
-    frame.path(
+    context.path(
         |path| {
             path.rect((ax - 20.0, ay - 20.0), (40.0, 40.0));
             path.move_to((0.0, 0.0));
@@ -829,7 +829,7 @@ fn draw_color_wheel(frame: &Frame, x: f32, y: f32, w: f32, h: f32, t: f32) {
     );
 }
 
-fn draw_lines(frame: &Frame, x: f32, y: f32, w: f32, _h: f32, t: f32) {
+fn draw_lines(context: &Context, x: f32, y: f32, w: f32, _h: f32, t: f32) {
     let pad = 5.0;
     let s = w / 9.0 - pad * 2.0;
     let mut pts = [0.0f32; 4 * 2];
@@ -853,7 +853,7 @@ fn draw_lines(frame: &Frame, x: f32, y: f32, w: f32, _h: f32, t: f32) {
             let cap = caps[i];
             let join = joins[j];
 
-            frame.path(
+            context.path(
                 |path| {
                     path.move_to((fx + pts[0], fy + pts[1]));
                     path.line_to((fx + pts[2], fy + pts[3]));
@@ -871,7 +871,7 @@ fn draw_lines(frame: &Frame, x: f32, y: f32, w: f32, _h: f32, t: f32) {
                 Default::default(),
             );
 
-            frame.path(
+            context.path(
                 |path| {
                     path.move_to((fx + pts[0], fy + pts[1]));
                     path.line_to((fx + pts[2], fy + pts[3]));
@@ -892,12 +892,12 @@ fn draw_lines(frame: &Frame, x: f32, y: f32, w: f32, _h: f32, t: f32) {
     }
 }
 
-fn draw_widths(frame: &Frame, x: f32, y: f32, width: f32) {
+fn draw_widths(context: &Context, x: f32, y: f32, width: f32) {
     let mut y = y;
 
     for i in 0..20 {
         let w = (i as f32 + 0.5) * 0.1;
-        frame.path(
+        context.path(
             |path| {
                 path.move_to((x, y));
                 path.line_to((x + width, y + width * 0.3));
@@ -915,11 +915,11 @@ fn draw_widths(frame: &Frame, x: f32, y: f32, width: f32) {
     }
 }
 
-fn draw_caps(frame: &Frame, x: f32, y: f32, width: f32) {
+fn draw_caps(context: &Context, x: f32, y: f32, width: f32) {
     let caps = [LineCap::Butt, LineCap::Round, LineCap::Square];
     let line_width = 8.0;
 
-    frame.path(
+    context.path(
         |path| {
             path.rect((x - line_width / 2.0, y), (width + line_width, 40.0));
             path.fill(FillStyle {
@@ -930,7 +930,7 @@ fn draw_caps(frame: &Frame, x: f32, y: f32, width: f32) {
         Default::default(),
     );
 
-    frame.path(
+    context.path(
         |path| {
             path.rect((x, y), (width, 40.0));
             path.fill(FillStyle {
@@ -942,7 +942,7 @@ fn draw_caps(frame: &Frame, x: f32, y: f32, width: f32) {
     );
 
     for i in 0..caps.len() {
-        frame.path(
+        context.path(
             |path| {
                 path.move_to((x, y + i as f32 * 10.0 + 5.0));
                 path.line_to((x + width, y + i as f32 * 10.0 + 5.0));
@@ -959,7 +959,7 @@ fn draw_caps(frame: &Frame, x: f32, y: f32, width: f32) {
     }
 }
 
-fn draw_scissor(frame: &Frame, x: f32, y: f32, t: f32) {
+fn draw_scissor(context: &Context, x: f32, y: f32, t: f32) {
     let first_transform = Transform::new().translate(x, y).rotate(5.0f32.to_radians());
 
     // let scissor_rect = Scissor::Rect {
@@ -977,7 +977,7 @@ fn draw_scissor(frame: &Frame, x: f32, y: f32, t: f32) {
     };
 
     // draw scissor area as a rect
-    frame.path(
+    context.path(
         |path| {
             path.rect((-20.0, -20.0), (60.0, 40.0));
             path.fill(FillStyle {
@@ -995,7 +995,7 @@ fn draw_scissor(frame: &Frame, x: f32, y: f32, t: f32) {
     // let transform = transform.translate(40.0, 0.0).rotate(t);
     let second_transform = first_transform.translate(40.0, 0.0).rotate(t);
 
-    frame.path(
+    context.path(
         |path| {
             path.rect((-20.0, -10.0), (60.0, 30.0));
             path.fill(FillStyle {
@@ -1010,7 +1010,7 @@ fn draw_scissor(frame: &Frame, x: f32, y: f32, t: f32) {
         },
     );
 
-    frame.path(
+    context.path(
         |path| {
             path.rect((-20.0, -10.0), (60.0, 30.0));
             path.fill(FillStyle {
@@ -1026,11 +1026,11 @@ fn draw_scissor(frame: &Frame, x: f32, y: f32, t: f32) {
     );
 }
 
-fn draw_window(frame: &Frame, fonts: &DemoFonts, title: &str, x: f32, y: f32, w: f32, h: f32) {
+fn draw_window(context: &Context, fonts: &DemoFonts, title: &str, x: f32, y: f32, w: f32, h: f32) {
     let corner_radius = 3.0;
 
     // window background
-    frame.path(
+    context.path(
         |path| {
             path.rounded_rect((x, y), (w, h), corner_radius);
             path.fill(FillStyle {
@@ -1042,7 +1042,7 @@ fn draw_window(frame: &Frame, fonts: &DemoFonts, title: &str, x: f32, y: f32, w:
     );
 
     // drop shadow
-    frame.path(
+    context.path(
         |path| {
             path.rect((x - 10.0, y - 10.0), (w + 20.0, h + 30.0));
             path.move_to((x, y));
@@ -1064,7 +1064,7 @@ fn draw_window(frame: &Frame, fonts: &DemoFonts, title: &str, x: f32, y: f32, w:
     );
 
     // header
-    frame.path(
+    context.path(
         |path| {
             path.rounded_rect((x + 1.0, y + 1.0), (w - 2.0, 30.0), corner_radius - 1.0);
             path.fill(FillStyle {
@@ -1081,7 +1081,7 @@ fn draw_window(frame: &Frame, fonts: &DemoFonts, title: &str, x: f32, y: f32, w:
     );
 
     // header separator
-    frame.path(
+    context.path(
         |path| {
             path.move_to((x + 0.5, y + 0.5 + 30.0));
             path.line_to((x + 0.5 + w - 1.0, y + 0.5 + 30.0));
@@ -1095,7 +1095,7 @@ fn draw_window(frame: &Frame, fonts: &DemoFonts, title: &str, x: f32, y: f32, w:
     );
 
     // header text
-    frame.context().text(
+    context.text(
         fonts.sans_bold,
         (x + w / 2.0, y + 16.0),
         title,
@@ -1108,7 +1108,7 @@ fn draw_window(frame: &Frame, fonts: &DemoFonts, title: &str, x: f32, y: f32, w:
         },
     );
 
-    frame.context().text(
+    context.text(
         fonts.sans_bold,
         (x + w / 2.0, y + 16.0),
         title,
@@ -1122,11 +1122,11 @@ fn draw_window(frame: &Frame, fonts: &DemoFonts, title: &str, x: f32, y: f32, w:
     );
 }
 
-fn draw_search_box(frame: &Frame, fonts: &DemoFonts, text: &str, x: f32, y: f32, w: f32, h: f32) {
+fn draw_search_box(context: &Context, fonts: &DemoFonts, text: &str, x: f32, y: f32, w: f32, h: f32) {
     let corner_radius = h / 2.0 - 1.0;
 
     // background rounded rectangle
-    frame.path(
+    context.path(
         |path| {
             path.rounded_rect((x, y), (w, h), corner_radius);
             path.fill(FillStyle {
@@ -1144,7 +1144,7 @@ fn draw_search_box(frame: &Frame, fonts: &DemoFonts, text: &str, x: f32, y: f32,
         Default::default(),
     );
 
-    frame.context().text(
+    context.text(
         fonts.icons,
         (x + h * 0.55, y + h * 0.55),
         ICON_SEARCH,
@@ -1156,7 +1156,7 @@ fn draw_search_box(frame: &Frame, fonts: &DemoFonts, text: &str, x: f32, y: f32,
         },
     );
 
-    frame.context().text(
+    context.text(
         fonts.sans,
         (x + h * 1.05, y + h * 0.5),
         text,
@@ -1168,7 +1168,7 @@ fn draw_search_box(frame: &Frame, fonts: &DemoFonts, text: &str, x: f32, y: f32,
         },
     );
 
-    frame.context().text(
+    context.text(
         fonts.icons,
         (x + w - h * 0.55, y + h * 0.55),
         ICON_CIRCLED_CROSS,
@@ -1181,11 +1181,11 @@ fn draw_search_box(frame: &Frame, fonts: &DemoFonts, text: &str, x: f32, y: f32,
     );
 }
 
-fn draw_drop_down(frame: &Frame, fonts: &DemoFonts, text: &str, x: f32, y: f32, w: f32, h: f32) {
+fn draw_drop_down(context: &Context, fonts: &DemoFonts, text: &str, x: f32, y: f32, w: f32, h: f32) {
     let corner_radius = 4.0;
 
     // drop down button with linear gradient
-    frame.path(
+    context.path(
         |path| {
             path.rounded_rect((x + 1.0, y + 1.0), (w - 2.0, h - 2.0), corner_radius - 1.0);
             path.fill(FillStyle {
@@ -1202,7 +1202,7 @@ fn draw_drop_down(frame: &Frame, fonts: &DemoFonts, text: &str, x: f32, y: f32, 
     );
 
     // border arond drop down
-    frame.path(
+    context.path(
         |path| {
             path.rounded_rect((x + 0.5, y + 0.5), (w - 1.0, h - 1.0), corner_radius - 0.5);
             path.stroke(StrokeStyle {
@@ -1214,7 +1214,7 @@ fn draw_drop_down(frame: &Frame, fonts: &DemoFonts, text: &str, x: f32, y: f32, 
     );
 
     // main drop down text
-    frame.context().text(
+    context.text(
         fonts.sans,
         (x + h * 0.3, y + h * 0.5),
         text,
@@ -1227,7 +1227,7 @@ fn draw_drop_down(frame: &Frame, fonts: &DemoFonts, text: &str, x: f32, y: f32, 
     );
 
     // chevron on right
-    frame.context().text(
+    context.text(
         fonts.icons,
         (x + w - h * 0.5, y + h * 0.5),
         ICON_CHEVRON_RIGHT,
@@ -1240,8 +1240,8 @@ fn draw_drop_down(frame: &Frame, fonts: &DemoFonts, text: &str, x: f32, y: f32, 
     );
 }
 
-fn draw_label(frame: &Frame, fonts: &DemoFonts, text: &str, x: f32, y: f32, _w: f32, h: f32) {
-    frame.context().text(
+fn draw_label(context: &Context, fonts: &DemoFonts, text: &str, x: f32, y: f32, _w: f32, h: f32) {
+    context.text(
         fonts.sans,
         (x, y + h * 0.5),
         text,
@@ -1254,11 +1254,11 @@ fn draw_label(frame: &Frame, fonts: &DemoFonts, text: &str, x: f32, y: f32, _w: 
     );
 }
 
-fn draw_edit_box_base(frame: &Frame, x: f32, y: f32, w: f32, h: f32) {
+fn draw_edit_box_base(context: &Context, x: f32, y: f32, w: f32, h: f32) {
     let corner_radius = 4.0;
 
     // base background
-    frame.path(
+    context.path(
         |path| {
             path.rounded_rect((x + 1.0, y + 1.0), (w - 2.0, h - 2.0), corner_radius - 1.0);
             path.fill(FillStyle {
@@ -1277,7 +1277,7 @@ fn draw_edit_box_base(frame: &Frame, x: f32, y: f32, w: f32, h: f32) {
     );
 
     // base border
-    frame.path(
+    context.path(
         |path| {
             path.rounded_rect((x + 0.5, y + 0.5), (w - 1.0, h - 1.0), corner_radius - 0.5);
             path.stroke(StrokeStyle {
@@ -1289,10 +1289,10 @@ fn draw_edit_box_base(frame: &Frame, x: f32, y: f32, w: f32, h: f32) {
     );
 }
 
-fn draw_edit_box(frame: &Frame, fonts: &DemoFonts, text: &str, x: f32, y: f32, w: f32, h: f32) {
-    draw_edit_box_base(frame, x, y, w, h);
+fn draw_edit_box(context: &Context, fonts: &DemoFonts, text: &str, x: f32, y: f32, w: f32, h: f32) {
+    draw_edit_box_base(context, x, y, w, h);
 
-    frame.context().text(
+    context.text(
         fonts.sans,
         (x + h * 0.3, y + h * 0.5),
         text,
@@ -1305,8 +1305,8 @@ fn draw_edit_box(frame: &Frame, fonts: &DemoFonts, text: &str, x: f32, y: f32, w
     );
 }
 
-fn draw_edit_box_num(frame: &Frame, fonts: &DemoFonts, text: &str, units: &str, x: f32, y: f32, w: f32, h: f32) {
-    draw_edit_box_base(frame, x, y, w, h);
+fn draw_edit_box_num(context: &Context, fonts: &DemoFonts, text: &str, units: &str, x: f32, y: f32, w: f32, h: f32) {
+    draw_edit_box_base(context, x, y, w, h);
 
     let units_options = TextOptions {
         size: 18.0,
@@ -1315,11 +1315,11 @@ fn draw_edit_box_num(frame: &Frame, fonts: &DemoFonts, text: &str, units: &str, 
         ..Default::default()
     };
 
-    let (uw, _) = frame.context().text_bounds(fonts.sans, (0.0, 0.0), units, units_options);
+    let (uw, _) = context.text_bounds(fonts.sans, (0.0, 0.0), units, units_options);
 
-    frame.context().text(fonts.sans, (x + w - h * 0.3, y + h * 0.5), units, units_options);
+    context.text(fonts.sans, (x + w - h * 0.3, y + h * 0.5), units, units_options);
 
-    frame.context().text(
+    context.text(
         fonts.sans,
         (x + w - uw - h * 0.5, y + h * 0.5),
         text,
@@ -1332,9 +1332,9 @@ fn draw_edit_box_num(frame: &Frame, fonts: &DemoFonts, text: &str, units: &str, 
     );
 }
 
-fn draw_check_box(frame: &Frame, fonts: &DemoFonts, text: &str, x: f32, y: f32, _w: f32, h: f32) {
+fn draw_check_box(context: &Context, fonts: &DemoFonts, text: &str, x: f32, y: f32, _w: f32, h: f32) {
     // checkbox text
-    frame.context().text(
+    context.text(
         fonts.sans,
         (x + 28.0, y + h * 0.5),
         text,
@@ -1347,7 +1347,7 @@ fn draw_check_box(frame: &Frame, fonts: &DemoFonts, text: &str, x: f32, y: f32, 
     );
 
     // tick box
-    frame.path(
+    context.path(
         |path| {
             path.rounded_rect((x + 1.0, y + h * 0.5 - 9.0), (18.0, 18.0), 3.0);
             path.fill(FillStyle {
@@ -1366,7 +1366,7 @@ fn draw_check_box(frame: &Frame, fonts: &DemoFonts, text: &str, x: f32, y: f32, 
     );
 
     // tick icon
-    frame.context().text(
+    context.text(
         fonts.icons,
         (x + 9.0 + 2.0, y + h * 0.5),
         ICON_CHECK,
@@ -1379,12 +1379,12 @@ fn draw_check_box(frame: &Frame, fonts: &DemoFonts, text: &str, x: f32, y: f32, 
     );
 }
 
-fn draw_button(frame: &Frame, fonts: &DemoFonts, preicon: Option<&str>, text: &str, x: f32, y: f32, w: f32, h: f32, color: Color) {
+fn draw_button(context: &Context, fonts: &DemoFonts, preicon: Option<&str>, text: &str, x: f32, y: f32, w: f32, h: f32, color: Color) {
     let corner_radius = 4.0;
     let color_is_black = is_black(color);
 
     // button background
-    frame.path(
+    context.path(
         |path| {
             path.rounded_rect((x + 1.0, y + 1.0), (w - 2.0, h - 2.0), corner_radius - 0.5);
             if !color_is_black {
@@ -1408,7 +1408,7 @@ fn draw_button(frame: &Frame, fonts: &DemoFonts, preicon: Option<&str>, text: &s
     );
 
     // button border
-    frame.path(
+    context.path(
         |path| {
             path.rounded_rect((x + 0.5, y + 0.5), (w - 1.0, h - 1.0), corner_radius - 0.5);
             path.stroke(StrokeStyle {
@@ -1419,7 +1419,7 @@ fn draw_button(frame: &Frame, fonts: &DemoFonts, preicon: Option<&str>, text: &s
         Default::default(),
     );
 
-    let (tw, _) = frame.context().text_bounds(
+    let (tw, _) = context.text_bounds(
         fonts.sans_bold,
         (0.0, 0.0),
         text,
@@ -1439,10 +1439,10 @@ fn draw_button(frame: &Frame, fonts: &DemoFonts, preicon: Option<&str>, text: &s
             ..Default::default()
         };
 
-        iw = frame.context().text_bounds(fonts.icons, (0.0, 0.0), icon, icon_options).0;
+        iw = context.text_bounds(fonts.icons, (0.0, 0.0), icon, icon_options).0;
         iw += h * 0.15;
 
-        frame.context().text(
+        context.text(
             fonts.icons,
             (x + w * 0.5 - tw * 0.5 - iw * 0.75, y + h * 0.5),
             icon,
@@ -1458,7 +1458,7 @@ fn draw_button(frame: &Frame, fonts: &DemoFonts, preicon: Option<&str>, text: &s
 
     options.color = Color::from_rgba(0, 0, 0, 160);
 
-    frame.context().text(
+    context.text(
         fonts.sans_bold,
         (x + w * 0.5 - tw * 0.5 + iw * 0.25, y + h * 0.5 - 1.0),
         text,
@@ -1467,7 +1467,7 @@ fn draw_button(frame: &Frame, fonts: &DemoFonts, preicon: Option<&str>, text: &s
 
     options.color = Color::from_rgba(255, 255, 255, 160);
 
-    frame.context().text(
+    context.text(
         fonts.sans_bold,
         (x + w * 0.5 - tw * 0.5 + iw * 0.25, y + h * 0.5),
         text,
@@ -1475,13 +1475,13 @@ fn draw_button(frame: &Frame, fonts: &DemoFonts, preicon: Option<&str>, text: &s
     );
 }
 
-fn draw_slider(frame: &Frame, value: f32, x: f32, y: f32, w: f32, h: f32) {
+fn draw_slider(context: &Context, value: f32, x: f32, y: f32, w: f32, h: f32) {
     let cy = y + h * 0.5;
     let kr = h * 0.25;
     let corner_radius = 2.0;
 
     // slot bar
-    frame.path(
+    context.path(
         |path| {
             path.rounded_rect((x, cy - 2.0), (w, 4.0), corner_radius);
             path.fill(FillStyle {
@@ -1500,7 +1500,7 @@ fn draw_slider(frame: &Frame, value: f32, x: f32, y: f32, w: f32, h: f32) {
     );
 
     // knob shadow
-    frame.path(
+    context.path(
         |path| {
             path.rect(
                 (x + (value * w) - kr - 5.0, cy - kr - 5.0),
@@ -1525,7 +1525,7 @@ fn draw_slider(frame: &Frame, value: f32, x: f32, y: f32, w: f32, h: f32) {
     );
 
     // knob
-    frame.path(
+    context.path(
         |path| {
             path.circle((x + (value * w), cy), kr - 1.0);
             path.fill(FillStyle {
@@ -1547,7 +1547,7 @@ fn draw_slider(frame: &Frame, value: f32, x: f32, y: f32, w: f32, h: f32) {
     );
 
     // knob outline
-    frame.path(
+    context.path(
         |path| {
             path.circle((x + value * w, cy), kr - 0.5);
             path.stroke(StrokeStyle {
@@ -1559,12 +1559,12 @@ fn draw_slider(frame: &Frame, value: f32, x: f32, y: f32, w: f32, h: f32) {
     );
 }
 
-fn draw_thumbnails(frame: &Frame, images: &Vec<Image>, x: f32, y: f32, w: f32, h: f32, t: f32) {
+fn draw_thumbnails(context: &Context, images: &Vec<Image>, x: f32, y: f32, w: f32, h: f32, t: f32) {
     let corner_radius = 3.0;
     let thumb = 60.0;
     let stackh = (images.len() / 2) as f32 * (thumb + 10.0) + 10.0;
 
-    frame.path(
+    context.path(
         |path| {
             path.rect((x - 10.0, y - 10.0), (w + 20.0, h + 30.0));
             path.move_to((x, y));
@@ -1586,7 +1586,7 @@ fn draw_thumbnails(frame: &Frame, images: &Vec<Image>, x: f32, y: f32, w: f32, h
     );
 
     // left arrow
-    frame.path(
+    context.path(
         |path| {
             let arry = 30.5;
             path.rounded_rect((x, y), (w, h), corner_radius);
@@ -1640,11 +1640,11 @@ fn draw_thumbnails(frame: &Frame, images: &Vec<Image>, x: f32, y: f32, w: f32, h
         };
 
         if a < 1.0 {
-            draw_spinner(frame, path_opts, tx + thumb / 2.0, ty + thumb / 2.0, thumb * 0.25, t);
+            draw_spinner(context, path_opts, tx + thumb / 2.0, ty + thumb / 2.0, thumb * 0.25, t);
         }
 
         // draw image
-        frame.path(
+        context.path(
             |path| {
                 path.rounded_rect((tx, ty), (thumb, thumb), 5.0);
                 path.fill(FillStyle {
@@ -1662,7 +1662,7 @@ fn draw_thumbnails(frame: &Frame, images: &Vec<Image>, x: f32, y: f32, w: f32, h
         );
 
         // draw image background shade
-        frame.path(
+        context.path(
             |path| {
                 path.rect((tx - 5.0, ty - 5.0), (thumb + 10.0, thumb + 10.0));
                 path.move_to((tx, ty));
@@ -1684,7 +1684,7 @@ fn draw_thumbnails(frame: &Frame, images: &Vec<Image>, x: f32, y: f32, w: f32, h
         );
 
         // draw image border
-        frame.path(
+        context.path(
             |path| {
                 path.rounded_rect((tx + 0.5, ty + 0.5), (thumb - 1.0, thumb - 1.0), 4.0 - 0.5);
                 path.stroke(StrokeStyle {
@@ -1698,7 +1698,7 @@ fn draw_thumbnails(frame: &Frame, images: &Vec<Image>, x: f32, y: f32, w: f32, h
     }
 
     // white fade border (top)
-    frame.path(
+    context.path(
         |path| {
             path.rect((x + 4.0, y), (w - 8.0, 6.0));
             path.fill(FillStyle {
@@ -1715,7 +1715,7 @@ fn draw_thumbnails(frame: &Frame, images: &Vec<Image>, x: f32, y: f32, w: f32, h
     );
 
     // white fade border (bottom)
-    frame.path(
+    context.path(
         |path| {
             path.rect((x + 4.0, y + h - 6.0), (w - 8.0, 6.0));
             path.fill(FillStyle {
@@ -1732,7 +1732,7 @@ fn draw_thumbnails(frame: &Frame, images: &Vec<Image>, x: f32, y: f32, w: f32, h
     );
 
     // scrollbar socket
-    frame.path(
+    context.path(
         |path| {
             path.rounded_rect((x + w - 12.0, y + 4.0), (8.0, h - 8.0), 3.0);
             path.fill(FillStyle {
@@ -1752,7 +1752,7 @@ fn draw_thumbnails(frame: &Frame, images: &Vec<Image>, x: f32, y: f32, w: f32, h
 
     let scrollh = (h / stackh) * (h - 8.0);
     // scrollbar thumb
-    frame.path(
+    context.path(
         |path| {
             path.rounded_rect(
                 (x + w - 12.0 + 1.0, y + 4.0 + 1.0 + (h - 8.0 - scrollh) * u),
@@ -1775,13 +1775,13 @@ fn draw_thumbnails(frame: &Frame, images: &Vec<Image>, x: f32, y: f32, w: f32, h
     );
 }
 
-fn draw_spinner(frame: &Frame, options: PathOptions, cx: f32, cy: f32, r: f32, t: f32) {
+fn draw_spinner(context: &Context, options: PathOptions, cx: f32, cy: f32, r: f32, t: f32) {
     let a0 = 0.0 + t * 6.0;
     let a1 = consts::PI + t * 6.0;
     let r0 = r;
     let r1 = r * 0.75;
 
-    frame.path(
+    context.path(
         |path| {
             let ax = cx + f32::cos(a0) * (r0 + r1) * 0.5;
             let ay = cy + f32::sin(a0) * (r0 + r1) * 0.5;
@@ -1826,17 +1826,17 @@ impl PerformanceGraph {
         }
     }
 
-    fn update(&mut self, frame_time: f32) {
+    fn update(&mut self, context_time: f32) {
         self.head = (self.head + 1) % GRAPH_HISTORY_COUNT;
-        self.values[self.head] = frame_time;
+        self.values[self.head] = context_time;
     }
 
-    fn draw(&self, frame: &Frame, font: Font, x: f32, y: f32) {
+    fn draw(&self, context: &Context, font: Font, x: f32, y: f32) {
         let w = 200.0;
         let h = 35.0;
         let average = self.average();
 
-        frame.path(
+        context.path(
             |path| {
                 path.rect((x, y), (w, h));
                 path.fill(FillStyle {
@@ -1847,7 +1847,7 @@ impl PerformanceGraph {
             Default::default()
         );
 
-        frame.path(
+        context.path(
             |path| {
                 path.move_to((x, y + h));
                 match self.style {
@@ -1890,7 +1890,7 @@ impl PerformanceGraph {
             Default::default()
         );
 
-        frame.context().text(font, (x + 3.0, y + 1.0), &self.name, TextOptions {
+        context.text(font, (x + 3.0, y + 1.0), &self.name, TextOptions {
             color: Color::from_rgba(240, 240, 240, 192),
             align: Alignment::new().left().top(),
             size: 14.0,
@@ -1899,7 +1899,7 @@ impl PerformanceGraph {
 
         match self.style {
             GraphRenderStyle::Fps => {
-                frame.context().text(
+                context.text(
                     font,
                     (x + w - 3.0, y + 1.0),
                     format!("{:.2} FPS", 1.0 / average),
@@ -1911,7 +1911,7 @@ impl PerformanceGraph {
                     }
                 );
 
-                frame.context().text(
+                context.text(
                     font,
                     (x + w - 3.0, y + h - 1.0),
                     format!("{:.2} ms", average * 1000.0),
@@ -1924,7 +1924,7 @@ impl PerformanceGraph {
                 );
             },
             GraphRenderStyle::Ms => {
-                frame.context().text(
+                context.text(
                     font,
                     (x + w - 3.0, y + 1.0),
                     format!("{:.2} ms", average * 1000.0),
@@ -1937,7 +1937,7 @@ impl PerformanceGraph {
                 );
             },
             GraphRenderStyle::Percent => {
-                frame.context().text(
+                context.text(
                     font,
                     (x + w - 3.0, y + 1.0),
                     format!("{:.1} %", average * 1.0),


### PR DESCRIPTION
I removed Frame for drawing paths and put path function into Context struct to be more in line with the c api of nanovg, but I wanted some feedback, because I don't know if this is the right way.

What was my intention with this, is when you have function for drawing some composite shape or widget, I wanted it to be more straightforward.
Example:
I wanted this:
```
fn button(context: &Context, ......) {
    context.path(|path| {
        path.rect(...);
    });
    context.text(...);
}
```
Instead of this:
```
fn button(frame: &Frame, ......) {
    frame.path(|path| {
        path.rect(...);
    });
    frame.context().text(...);
}
```
What I don't like here is the indirection.
I considered putting everything into Frame and keeping only .frame function in Context, but then I looked at the c-api and saw that everything takes context, there is no frame struct, only beginFrame, endFrame functions.

So I would like an opinion on this, if you think it's not worth it, feel free to close this PR.