### PR TITLE
Remove libc dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ gles2 = []
 gles3 = []
 
 [dependencies]
-libc = "0.2"
 bitflags = "1.0"
 
 [build-dependencies]

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,7 +1,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-use libc::{c_char, c_uchar, c_int, c_float, c_void};
+use std::os::raw::{c_char, c_uchar, c_int, c_float, c_void};
 
 pub const FONS_INVALID: c_int = -1;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,12 @@
 #[macro_use]
 extern crate bitflags;
-extern crate libc;
 
 pub mod ffi;
 
 use std::ops::Drop;
 use std::path::Path as IoPath;
 use std::ffi::{NulError, CString};
-use libc::{c_int, c_float, c_uchar, c_char};
+use std::os::raw::{c_int, c_float, c_uchar, c_char};
 
 #[cfg(target_os = "windows")]
 fn init_gl() -> Result<(), ()> {


### PR DESCRIPTION
libc dependency is not needed, we use it only for c types aliases, and they are also defined in the standard library, so we use that instead of libc