### PR TITLE
Remove GlyphPosition's next field in favor of .peekable()

### DIFF
--- a/examples/demo-text.rs
+++ b/examples/demo-text.rs
@@ -188,9 +188,10 @@ fn draw_paragraph(frame: &Frame, font: Font, x: f32, y: f32, width: f32, _height
             let mut px = x;
 
             // calculate mouse caret position
-            for glyph in frame.text_glyph_positions((x, y), row.text) {
+            let mut glyph_positions = frame.text_glyph_positions((x, y), row.text).peekable();
+            while let Some(glyph) = glyph_positions.next() {
                 let x0 = glyph.x;
-                let x1 = if let Some(next) = glyph.next { next.x } else { x + row.width };
+                let x1 = if let Some(next) = glyph_positions.peek() { next.x } else { x + row.width };
                 let gx = x0 * 0.3 + x1 * 0.7;
 
                 if mx >= px && mx < gx {

--- a/examples/demo-ui.rs
+++ b/examples/demo-ui.rs
@@ -397,9 +397,10 @@ fn draw_paragraph(frame: &Frame, fonts: &DemoFonts, x: f32, y: f32, width: f32, 
             let mut px = x;
 
             // calculate mouse caret position
-            for glyph in frame.text_glyph_positions((x, y), row.text) {
+            let mut glyph_positions = frame.text_glyph_positions((x, y), row.text).peekable();
+            while let Some(glyph) = glyph_positions.next() {
                 let x0 = glyph.x;
-                let x1 = if let Some(next) = glyph.next { next.x } else { x + row.width };
+                let x1 = if let Some(next) = glyph_positions.peek() { next.x } else { x + row.width };
                 let gx = x0 * 0.3 + x1 * 0.7;
 
                 if mx >= px && mx < gx {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -513,6 +513,7 @@ impl<'a> Frame<'a> {
     /// Returns iterator over all glyph positions in text.
     /// `(x, y)` the coordinate space from which to offset coordinates in `GlyphPosition`
     /// `text` the text to break into glyph positions
+    /// If you want to get current glyph and the next one, use .peekable() on this iterator.
     pub fn text_glyph_positions<S: AsRef<str>>(
         &self,
         (x, y): (f32, f32),
@@ -1612,24 +1613,13 @@ impl<'a> Iterator for TextGlyphPositions<'a> {
         match num_glyphs {
             1 => {
                 self.start = &('\0' as c_char);
-                Some(GlyphPosition::new(&self.glyphs[0], None))
+                Some(GlyphPosition::new(&self.glyphs[0]))
             },
             2 => {
                 self.x = self.glyphs[1].x;
                 self.start = self.glyphs[1].s;
 
-                Some(
-                    GlyphPosition::new(
-                        &self.glyphs[0],
-                        Some(Box::new(
-                                GlyphPosition::new(
-                                    &self.glyphs[1],
-                                    None
-                                )
-                            )
-                        )
-                    )
-                )
+                Some(GlyphPosition::new(&self.glyphs[0]))
             },
             _ => None
         }
@@ -1708,20 +1698,15 @@ pub struct GlyphPosition {
     pub x: f32,
     pub min_x: f32,
     pub max_x: f32,
-    /// Next GlyphPosition for convenience (stores only one glyph position in advance)
-    pub next: Option<Box<GlyphPosition>>,
 }
 
 impl GlyphPosition {
     /// Creates new GlyphPosition from raw nanovg glyph position.
-    /// We can optionally pass next glyph position
-    /// (there is usually some if it is not the last glyph in text, otherwise it is none for last glyph).
-    fn new(glyph: &ffi::NVGglyphPosition, next: Option<Box<GlyphPosition>>) -> GlyphPosition {
+    fn new(glyph: &ffi::NVGglyphPosition) -> GlyphPosition {
         GlyphPosition {
             x: glyph.x,
             min_x: glyph.minx,
             max_x: glyph.maxx,
-            next: next
         }
     }
 }


### PR DESCRIPTION
We can use .peekable() on TextGlyphPositions iterator to get the next
glyph if we want to, no need to store additional field for this purpose.

The only disadvantage is, that we have to use while loop instead of for loop, but I think, this is more clear and clarifies the usage and those who don't need .next are not confused.

Closes #68 