### PR TITLE
Fix cargo publish; fix linking errors when using backends other than GL3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,9 @@ gl2 = ["nanovg-sys/gl2"]
 gl3 = ["nanovg-sys/gl3"]
 gles2 = ["nanovg-sys/gles2"]
 gles3 = ["nanovg-sys/gles3"]
-default = ["gl3"]
 
 [dependencies]
-nanovg-sys = { path = "nanovg-sys", version = "0.1.2" }
+nanovg-sys = { path = "nanovg-sys", version = "0.1.2", default-features = false }
 
 [dev-dependencies]
 glutin = "0.13.0"

--- a/nanovg-sys/Cargo.toml
+++ b/nanovg-sys/Cargo.toml
@@ -16,6 +16,7 @@ name = "nanovg_sys"
 path = "lib.rs"
 
 [features]
+default = ["gl3"]
 gl2 = []
 gl3 = []
 gles2 = []


### PR DESCRIPTION
Referencing #56.

The linking error was caused by `nanovg-sys` being always built with `gl3`. The way feature selection works is that default features are always on unless explicitly turned off. In other words if I said:
```toml
nanovg-sys = { path = "nanovg-sys", features = ["gl2"]}
```
then because `nanovg-sys` defaults to:
```toml
default = ["gl3"]
```
the enabled features would be `gl3` and `gl2`. Now, because `build.rs` checks for `gl3` first, it would build with `gl3`. Hence the linking error.

As you said `nanovg-sys` won't build without a default feature so I gave it one and then disabled it in `nanovg-rs`. This works because `cargo publish` does not publish the binaries. It runs the clean build only as a validation check (afaik).

I also removed the default feature from `nanovg-rs` so that users don't have to set `default-features = false`. But this is a judgement call, maybe it should stay. Dunno.