### PR TITLE
Fix docs on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanovg"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Kevin Kelley <kevin@kelleysoft.com>"]
 readme = "README.md"
 description = "Idiomatic bindings to the NanoVG library"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["nanovg", "bindings", "vector", "graphics", "opengl"]
 categories = ["rendering::graphics-api", "games", "gui"]
 license = "MIT/Zlib"
 
+[package.metadata.docs.rs]
+features = ["gl3"]
+
 [lib]
 name = "nanovg"
 

--- a/nanovg-sys/Cargo.toml
+++ b/nanovg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanovg-sys"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Kevin Kelley <kevin@kelleysoft.com>"]
 build = "build.rs"
 links = "nanovg"

--- a/nanovg-sys/Cargo.toml
+++ b/nanovg-sys/Cargo.toml
@@ -11,6 +11,9 @@ keywords = ["nanovg", "bindings", "vector", "graphics", "opengl"]
 categories = ["rendering::graphics-api", "games", "gui"]
 license = "MIT/Zlib"
 
+[package.metadata.docs.rs]
+features = ["gl3"]
+
 [lib]
 name = "nanovg_sys"
 path = "lib.rs"


### PR DESCRIPTION
Looks like docs.rs needs to successfully build to generate the docs and since we no longer specify the default backend it fails: https://docs.rs/crate/nanovg/1.0.0

I added the required docs.rs-specific configuration to both crates so we aren't left doc-less 👿 (based on https://docs.rs/about).

#56 